### PR TITLE
Remove conda version pin

### DIFF
--- a/.azure-templates/linux.yml
+++ b/.azure-templates/linux.yml
@@ -21,7 +21,7 @@ jobs:
   - script: |
       conda config --system --set always_yes yes --set changeps1 no
       conda config --system --append channels conda-forge
-      conda install -n base conda-devenv conda=4.6.14
+      conda install -n base conda-devenv
     displayName: 'Configuring conda'
 
   - script: |

--- a/.azure-templates/win.yml
+++ b/.azure-templates/win.yml
@@ -21,7 +21,7 @@ jobs:
   - script: |
       conda config --system --set always_yes yes --set changeps1 no
       conda config --system --append channels conda-forge
-      conda install -n base conda-devenv conda=4.6.14
+      conda install -n base conda-devenv
     displayName: 'Configuring conda'
 
   - script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - export CONDA=$CONDA_BIN/conda
   - $CONDA config --system --set always_yes yes --set changeps1 false
   - $CONDA config --system --append channels conda-forge
-  - $CONDA install -n base conda-devenv conda=4.7.10
+  - $CONDA install -n base conda-devenv
 install:
   - |
     $CONDA devenv


### PR DESCRIPTION
Due to problems related to old `conda` versions, the version was pinned. In this PR, I remove this pin.